### PR TITLE
Stable / Preview update channels (Insider-style early access)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,6 +365,12 @@ jobs:
             dist/*.apk
           fail_on_unmatched_files: true
           generate_release_notes: true
+          # Insider/Preview channel: a tag carrying '-preview' (e.g.
+          # v0.99.0-preview1) publishes as a GitHub pre-release, which the
+          # /releases/latest API excludes — so Stable-channel hosts never see it
+          # and only Preview-channel hosts pick it up. A plain v0.99.0 tag stays
+          # a normal (latest) release.
+          prerelease: ${{ contains(github.ref, '-preview') }}
           body: |
             ## Install
 

--- a/src/NINA.Polaris/Endpoints/SystemEndpoints.cs
+++ b/src/NINA.Polaris/Endpoints/SystemEndpoints.cs
@@ -254,6 +254,10 @@ public static class SystemEndpoints {
                 p.IndiHost = update.IndiHost;
                 p.IndiPort = update.IndiPort;
                 p.AutoConnectOnStartup = update.AutoConnectOnStartup;
+                // Self-update channel: only "preview" or "stable" (anything else
+                // normalises to stable so a bad value can't strand a host).
+                p.UpdateChannel = string.Equals(update.UpdateChannel?.Trim(), "preview",
+                    StringComparison.OrdinalIgnoreCase) ? "preview" : "stable";
                 p.AstapPath = update.AstapPath;
                 p.SolveToleranceArcsec = update.SolveToleranceArcsec;
                 // The Studio root (ImageOutputDir) is set through its own

--- a/src/NINA.Polaris/Services/External/UpdateService.cs
+++ b/src/NINA.Polaris/Services/External/UpdateService.cs
@@ -43,16 +43,26 @@ public class UpdateService {
 
     private readonly ILogger<UpdateService> _logger;
     private readonly IHttpClientFactory _httpFactory;
+    private readonly ProfileService _profiles;
 
     private readonly object _cacheLock = new();
     private UpdateCheckResult? _cached;
     private DateTime _cachedAtUtc = DateTime.MinValue;
+    private string _cachedChannel = "stable";
     private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(30);
 
-    public UpdateService(ILogger<UpdateService> logger, IHttpClientFactory httpFactory) {
+    public UpdateService(ILogger<UpdateService> logger, IHttpClientFactory httpFactory,
+            ProfileService profiles) {
         _logger = logger;
         _httpFactory = httpFactory;
+        _profiles = profiles;
     }
+
+    /// <summary>The active update channel: "preview" opts into pre-releases,
+    /// anything else is the default "stable". Global (UserProfile), not per-rig.</summary>
+    private string Channel =>
+        string.Equals(_profiles.Active.UpdateChannel?.Trim(), "preview", StringComparison.OrdinalIgnoreCase)
+            ? "preview" : "stable";
 
     /// <summary>True only on a Linux .deb install (systemd + /opt/polaris). The
     /// self-update flow assumes the packaged layout + service.</summary>
@@ -98,20 +108,33 @@ public class UpdateService {
         if (!IsSupported)
             return new UpdateCheckResult { Supported = false, CurrentVersion = CurrentVersionShort };
 
+        var channel = Channel;
+        bool preview = channel == "preview";
+
         lock (_cacheLock) {
-            if (!force && _cached != null && DateTime.UtcNow - _cachedAtUtc < CacheTtl)
+            if (!force && _cached != null && _cachedChannel == channel
+                    && DateTime.UtcNow - _cachedAtUtc < CacheTtl)
                 return _cached;
         }
 
         var result = new UpdateCheckResult {
             Supported = true,
+            Channel = channel,
             CurrentVersion = CurrentVersionShort,
             Arch = DpkgArch
         };
         try {
             var http = _httpFactory.CreateClient();
             http.Timeout = TimeSpan.FromSeconds(15);
-            using var req = new HttpRequestMessage(HttpMethod.Get, LatestReleaseApi);
+            // Stable = GitHub's "latest" (which excludes pre-releases). Preview =
+            // the releases LIST, from which we take the newest build that has an
+            // asset for this arch, INCLUDING pre-releases (GitHub lists newest
+            // first). So a stable host never sees a pre-release, and a preview
+            // host always gets the absolute newest build.
+            var apiUrl = preview
+                ? $"https://api.github.com/repos/{Repo}/releases?per_page=15"
+                : LatestReleaseApi;
+            using var req = new HttpRequestMessage(HttpMethod.Get, apiUrl);
             // GitHub requires a User-Agent; the versioned media type pins the API.
             req.Headers.UserAgent.ParseAdd("NINA.Polaris-Updater");
             req.Headers.Accept.ParseAdd("application/vnd.github+json");
@@ -121,7 +144,29 @@ public class UpdateService {
                 return CacheAndReturn(result);
             }
             using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct));
-            var root = doc.RootElement;
+
+            JsonElement root;
+            if (preview) {
+                if (doc.RootElement.ValueKind != JsonValueKind.Array) {
+                    result.Error = "Unexpected releases payload from GitHub";
+                    return CacheAndReturn(result);
+                }
+                JsonElement? picked = null;
+                foreach (var rel in doc.RootElement.EnumerateArray()) {
+                    var (_, aUrl, _) = PickArchAsset(rel);
+                    if (!string.IsNullOrEmpty(aUrl)) { picked = rel.Clone(); break; }
+                }
+                if (picked == null) {
+                    result.Error = $"No preview build for {DpkgArch} yet";
+                    return CacheAndReturn(result);
+                }
+                root = picked.Value;
+            } else {
+                root = doc.RootElement;
+            }
+
+            result.Prerelease = root.TryGetProperty("prerelease", out var prE)
+                                && prE.ValueKind == JsonValueKind.True;
 
             var tag = root.TryGetProperty("tag_name", out var t) ? t.GetString() : null;
             result.LatestVersion = NormalizeTag(tag);
@@ -161,7 +206,7 @@ public class UpdateService {
     }
 
     private UpdateCheckResult CacheAndReturn(UpdateCheckResult r) {
-        lock (_cacheLock) { _cached = r; _cachedAtUtc = DateTime.UtcNow; }
+        lock (_cacheLock) { _cached = r; _cachedAtUtc = DateTime.UtcNow; _cachedChannel = r.Channel; }
         return r;
     }
 
@@ -641,6 +686,12 @@ public class UpdateLocalInfo {
 public class UpdateCheckResult {
     public bool Supported { get; set; }
     public bool UpdateAvailable { get; set; }
+    /// <summary>Which update channel this check used: "stable" (GitHub latest
+    /// release) or "preview" (newest release including pre-releases).</summary>
+    public string Channel { get; set; } = "stable";
+    /// <summary>True when the offered release is a GitHub pre-release (only the
+    /// preview channel ever surfaces these).</summary>
+    public bool Prerelease { get; set; }
     public string CurrentVersion { get; set; } = "";
     public string? LatestVersion { get; set; }
     public string? ReleaseName { get; set; }

--- a/src/NINA.Polaris/Services/ProfileModels.cs
+++ b/src/NINA.Polaris/Services/ProfileModels.cs
@@ -49,6 +49,11 @@ public class UserProfile {
     /// powered up yet.</summary>
     public bool AutoConnectOnStartup { get; set; } = false;
 
+    /// <summary>Self-update channel: "stable" (default; GitHub's latest
+    /// non-prerelease) or "preview" (opts into pre-releases — the Insider-style
+    /// early-access channel for risky new features). Global, not per-rig.</summary>
+    public string UpdateChannel { get; set; } = "stable";
+
     // Legacy single-rig equipment selection (still serialised for
     // backward-compat; new code uses EquipmentProfiles below).
     public string? LastCamera { get; set; }

--- a/src/NINA.Polaris/wwwroot/data/locales/_source.json
+++ b/src/NINA.Polaris/wwwroot/data/locales/_source.json
@@ -3638,5 +3638,9 @@
   "ZWO preset gains": "",
   "ZWO preset gains, L=": "",
   "⚙ Serial ports": "",
-  "⟳ Sync past sessions": ""
+  "⟳ Sync past sessions": "",
+  "Update channel": "Update channel",
+  "Stable": "Stable",
+  "Preview (early access)": "Preview (early access)",
+  "Preview builds carry new, less-tested features. Use a test rig.": "Preview builds carry new, less-tested features. Use a test rig."
 }

--- a/src/NINA.Polaris/wwwroot/data/locales/de.json
+++ b/src/NINA.Polaris/wwwroot/data/locales/de.json
@@ -4263,5 +4263,9 @@
   "Zoom to fit (whole frame)": "Auf Bildgröße anpassen (ganzer Bildausschnitt)",
   "ZWO ASI SDK": "ZWO ASI SDK",
   "ZWO preset gains": "ZWO-Vorgabe-Gains",
-  "ZWO preset gains, L=": "ZWO-Vorgabe-Gains, L="
+  "ZWO preset gains, L=": "ZWO-Vorgabe-Gains, L=",
+  "Update channel": "Update-Kanal",
+  "Stable": "Stabil",
+  "Preview (early access)": "Vorschau (Frühzugang)",
+  "Preview builds carry new, less-tested features. Use a test rig.": "Vorschau-Builds enthalten neue, weniger getestete Funktionen. Nutze ein Test-Rig."
 }

--- a/src/NINA.Polaris/wwwroot/data/locales/es.json
+++ b/src/NINA.Polaris/wwwroot/data/locales/es.json
@@ -4263,5 +4263,9 @@
   "Zoom to fit (whole frame)": "Ajustar a pantalla completa (toda la imagen)",
   "ZWO ASI SDK": "ZWO ASI SDK",
   "ZWO preset gains": "Ganancias predefinidas ZWO",
-  "ZWO preset gains, L=": "Ganancias predefinidas ZWO, L="
+  "ZWO preset gains, L=": "Ganancias predefinidas ZWO, L=",
+  "Update channel": "Canal de actualización",
+  "Stable": "Estable",
+  "Preview (early access)": "Preview (acceso anticipado)",
+  "Preview builds carry new, less-tested features. Use a test rig.": "Las compilaciones de preview traen funciones nuevas y menos probadas. Usa un equipo de prueba."
 }

--- a/src/NINA.Polaris/wwwroot/data/locales/fr.json
+++ b/src/NINA.Polaris/wwwroot/data/locales/fr.json
@@ -4263,5 +4263,9 @@
   "Zoom to fit (whole frame)": "Zoom pour ajuster à l'image (plein écran)",
   "ZWO ASI SDK": "ZWO ASI SDK",
   "ZWO preset gains": "Gains prédéfinis ZWO",
-  "ZWO preset gains, L=": "Gains prédéfinis ZWO, L="
+  "ZWO preset gains, L=": "Gains prédéfinis ZWO, L=",
+  "Update channel": "Canal de mise à jour",
+  "Stable": "Stable",
+  "Preview (early access)": "Préversion (accès anticipé)",
+  "Preview builds carry new, less-tested features. Use a test rig.": "Les préversions apportent des fonctionnalités récentes et moins testées. Utilisez un banc de test."
 }

--- a/src/NINA.Polaris/wwwroot/data/locales/pt-BR.json
+++ b/src/NINA.Polaris/wwwroot/data/locales/pt-BR.json
@@ -4263,5 +4263,9 @@
   "Zoom to fit (whole frame)": "Ampliar para preencher a tela (tela inteira)",
   "ZWO ASI SDK": "ZWO ASI SDK",
   "ZWO preset gains": "Ganhos predefinidos ZWO",
-  "ZWO preset gains, L=": "Ganhos predefinidos ZWO, L="
+  "ZWO preset gains, L=": "Ganhos predefinidos ZWO, L=",
+  "Update channel": "Canal de atualização",
+  "Stable": "Estável",
+  "Preview (early access)": "Preview (acesso antecipado)",
+  "Preview builds carry new, less-tested features. Use a test rig.": "Builds de preview trazem recursos novos e menos testados. Use um rig de teste."
 }

--- a/src/NINA.Polaris/wwwroot/index.html
+++ b/src/NINA.Polaris/wwwroot/index.html
@@ -14305,6 +14305,20 @@ cd xpra-html5 &amp;&amp; sudo python3 ./setup.py install</pre>
                         previous version, all without an SSH session.
                     </p>
 
+                    <!-- Update channel: Stable (default) vs Preview (early access
+                         to risky features, shipped as GitHub pre-releases). -->
+                    <label style="display:flex; align-items:center; gap:10px; margin-top:12px; flex-wrap:wrap">
+                        <span x-text="$t('Update channel')"></span>
+                        <select class="input-sm" style="width:auto" x-model="settings.updateChannel"
+                                @change="saveSettingsToServer()">
+                            <option value="stable" x-text="$t('Stable')"></option>
+                            <option value="preview" x-text="$t('Preview (early access)')"></option>
+                        </select>
+                        <span class="text-warn" x-show="settings.updateChannel === 'preview'" x-cloak
+                              style="font-size:11px"
+                              x-text="$t('Preview builds carry new, less-tested features. Use a test rig.')"></span>
+                    </label>
+
                     <div style="display:flex; gap:8px; flex-wrap:wrap; margin-top:14px">
                         <button class="btn btn-sm"
                                 @click="checkUpdateManual()"

--- a/src/NINA.Polaris/wwwroot/js/app.js
+++ b/src/NINA.Polaris/wwwroot/js/app.js
@@ -1051,6 +1051,8 @@ function ninaApp() {
             // Boot-time auto-connect, INDI + Alpaca discovery +
             // active-rig device bind. Pushed by HardwareAutoConnectService.
             autoConnectOnStartup: false,
+            // Self-update channel: 'stable' or 'preview' (early-access).
+            updateChannel: 'stable',
             // External tools, see ExternalTools section in Settings.
             // Empty = auto-detect (BinaryLocator on the server picks
             // the right path for the host OS).
@@ -11461,6 +11463,7 @@ function ninaApp() {
                     this.settings.imageNamePattern = data.imageNamePattern || '';
                     this.settings.preferAdvancedSequencer = !!data.preferAdvancedSequencer;
                     this.settings.autoConnectOnStartup = !!data.autoConnectOnStartup;
+                    this.settings.updateChannel = data.updateChannel === 'preview' ? 'preview' : 'stable';
                     // DBGLOG-9: hydrate the persist-to-disk toggle (default on).
                     this.settings.logToDisk = data.logToDisk !== false;
                     this.settings.saveGuideLogs = data.saveGuideLogs !== false;
@@ -23390,6 +23393,7 @@ function ninaApp() {
                         imageNamePattern: this.settings.imageNamePattern,
                         preferAdvancedSequencer: this.settings.preferAdvancedSequencer,
                         autoConnectOnStartup: this.settings.autoConnectOnStartup,
+                        updateChannel: this.settings.updateChannel,
                         // DBGLOG-9: opt-in disk persistence.
                         logToDisk: this.settings.logToDisk,
                         saveGuideLogs: this.settings.saveGuideLogs,


### PR DESCRIPTION
## What

Adds an Insider-style **Preview** update channel alongside the default **Stable** one, so risky features can be shipped to opt-in testers via self-update without ever reaching Stable hosts.

The lever is GitHub pre-releases: `/releases/latest` (Stable) already excludes them, so the whole mechanism is a small client change + one CI line — no new servers or hosting.

## Changes

**Client**
- `UserProfile.UpdateChannel` (`stable` default / `preview`); global, saved through the settings PUT (normalised server-side so a bad value can't strand a host).
- `UpdateService` reads the channel: **stable** → GitHub `latest` (skips pre-releases, unchanged); **preview** → the releases list, newest arch-matched build **including pre-releases**.
- `UpdateCheckResult` carries `channel` + `prerelease`; the check cache is keyed by channel so flipping the toggle re-checks immediately.
- Software-update card gets a channel selector with a "use a test rig" warning on Preview.
- Getting back to stable already works via the existing rollback (`InstallVersionAsync`, `--allow-downgrades`).
- Strings translated (pt-BR / es / fr / de + `_source`).

**CI**
- `release.yml`: a tag containing `-preview` (e.g. `v0.99.0-preview1`) publishes as a GitHub pre-release; a plain `v0.99.0` stays a normal (latest) release.

## Why this must land on Stable first

The channel toggle has to ship in a Stable build so existing hosts have the switch to opt into Preview — otherwise it's chicken-and-egg (you'd need a Preview build to get the toggle to get a Preview build). So: merge here → cut a Stable release → then publish the first `-preview` release.

## Verification

- Build: 0 errors.
- Settings round-trip (`stable → preview → stable`) persists.
- WSL (Linux): both GitHub queries the updater uses resolve and pick `polaris_*_amd64.deb` correctly. They match today only because no pre-release exists yet; they diverge the moment a `-preview` tag is published.
- Not exercised: the full self-update on a real `.deb` host (needs `IsSupported` = Linux + `/opt/polaris` + systemd) and the actual stable-vs-preview divergence (needs a `-preview` release to exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)