### PR TITLE
fix: preserve absolute-form request paths in HTTPS redirects

### DIFF
--- a/src/NINA.Polaris/Middleware/PlaintextHttpOnTlsPort.cs
+++ b/src/NINA.Polaris/Middleware/PlaintextHttpOnTlsPort.cs
@@ -87,7 +87,15 @@ public static class PlaintextHttpOnTlsPort {
         int eol = text.IndexOf("\r\n", StringComparison.Ordinal);
         if (eol < 0) return len >= MaxPeek ? Verdict.Tls : Verdict.NeedMore;
         var parts = text[..eol].Split(' ');
-        string path = parts.Length >= 2 && parts[1].StartsWith('/') ? parts[1] : "/";
+        string target = parts.Length >= 2 ? parts[1] : "/";
+        string path = target.StartsWith('/')
+            ? target
+            : Uri.TryCreate(target, UriKind.Absolute, out var absoluteTarget)
+                && (absoluteTarget.Scheme == Uri.UriSchemeHttp || absoluteTarget.Scheme == Uri.UriSchemeHttps)
+                && !string.IsNullOrEmpty(absoluteTarget.Host)
+                ? absoluteTarget.PathAndQuery
+                : "/";
+        if (path.Length == 0) path = "/";
         string host = "";
         foreach (var line in text[(eol + 2)..].Split("\r\n")) {
             if (line.Length == 0) break;

--- a/tests/NINA.Polaris.Test/PlaintextHttpOnTlsPortTests.cs
+++ b/tests/NINA.Polaris.Test/PlaintextHttpOnTlsPortTests.cs
@@ -29,6 +29,20 @@ public class PlaintextHttpOnTlsPortTests {
     }
 
     [Test]
+    public void PlainGet_AbsoluteForm_PreservesPathAndQuery() {
+        var v = PlaintextHttpOnTlsPort.Inspect(Bytes("GET http://host:5000/video?x=1 HTTP/1.1\r\nHost: host:5000\r\n\r\n"), 5000, "1.2.3.4", out var loc);
+        Assert.That(v, Is.EqualTo(PlaintextHttpOnTlsPort.Verdict.Plaintext));
+        Assert.That(loc, Is.EqualTo("https://host:5000/video?x=1"));
+    }
+
+    [Test]
+    public void PlainGet_AbsoluteFormWithoutPath_RedirectsToRoot() {
+        var v = PlaintextHttpOnTlsPort.Inspect(Bytes("GET http://host:5000 HTTP/1.1\r\nHost: host:5000\r\n\r\n"), 5000, "1.2.3.4", out var loc);
+        Assert.That(v, Is.EqualTo(PlaintextHttpOnTlsPort.Verdict.Plaintext));
+        Assert.That(loc, Is.EqualTo("https://host:5000/"));
+    }
+
+    [Test]
     public void PlainGet_WithHostname_KeepsTheName() {
         var v = PlaintextHttpOnTlsPort.Inspect(Bytes("GET / HTTP/1.1\r\nHost: polaris-rpi.local\r\n\r\n"), 5000, "1.2.3.4", out var loc);
         Assert.That(v, Is.EqualTo(PlaintextHttpOnTlsPort.Verdict.Plaintext));


### PR DESCRIPTION
Fix the HTTPS-port redirect `middleware` so valid HTTP absolute-form requests preserve their path and query string instead of redirecting to `/`.

Add regression coverage for absolute-form requests with and without an explicit path.