### PR TITLE
fix: prevent symlink escapes in file path validation

### DIFF
--- a/src/NINA.Polaris/Services/FileBrowserService.cs
+++ b/src/NINA.Polaris/Services/FileBrowserService.cs
@@ -529,6 +529,12 @@ public class FileBrowserService {
         var full = Path.GetFullPath(userPath);
         if (mustExist && !File.Exists(full) && !Directory.Exists(full))
             throw new FileNotFoundException(full);
+        if (mustExist) {
+            FileSystemInfo info = Directory.Exists(full)
+                ? new DirectoryInfo(full)
+                : new FileInfo(full);
+            full = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? full;
+        }
         if (IsBlocked(full))
             throw new UnauthorizedAccessException($"Path is blocked: {full}");
         return full;
@@ -540,9 +546,25 @@ public class FileBrowserService {
         if (string.IsNullOrWhiteSpace(userPath))
             throw new ArgumentException("Empty destination", nameof(userPath));
         var full = Path.GetFullPath(userPath);
-        if (IsBlocked(full))
-            throw new UnauthorizedAccessException($"Destination is blocked: {full}");
-        return full;
+        if (File.Exists(full) || Directory.Exists(full))
+            return ResolveSafe(full, mustExist: true);
+
+        var missing = new Stack<string>();
+        var existing = full;
+        while (!File.Exists(existing) && !Directory.Exists(existing)) {
+            var parent = Path.GetDirectoryName(existing);
+            if (string.IsNullOrEmpty(parent) || parent == existing) break;
+            missing.Push(Path.GetFileName(existing));
+            existing = parent;
+        }
+
+        var canonical = File.Exists(existing) || Directory.Exists(existing)
+            ? ResolveSafe(existing, mustExist: true)
+            : existing;
+        while (missing.Count > 0) canonical = Path.Combine(canonical, missing.Pop());
+        if (IsBlocked(canonical))
+            throw new UnauthorizedAccessException($"Destination is blocked: {canonical}");
+        return canonical;
     }
 
     public static bool IsBlocked(string fullPath) {

--- a/src/NINA.Polaris/Services/FileBrowserService.cs
+++ b/src/NINA.Polaris/Services/FileBrowserService.cs
@@ -529,15 +529,32 @@ public class FileBrowserService {
         var full = Path.GetFullPath(userPath);
         if (mustExist && !File.Exists(full) && !Directory.Exists(full))
             throw new FileNotFoundException(full);
-        if (mustExist) {
-            FileSystemInfo info = Directory.Exists(full)
-                ? new DirectoryInfo(full)
-                : new FileInfo(full);
-            full = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? full;
-        }
+        // Validate and return the canonical target, not necessarily the requested path.
+        full = ResolveExistingPath(full);
         if (IsBlocked(full))
             throw new UnauthorizedAccessException($"Path is blocked: {full}");
         return full;
+    }
+
+    private static string ResolveExistingPath(string fullPath) {
+        var current = Path.GetPathRoot(fullPath)
+                      ?? throw new ArgumentException("Path has no root", nameof(fullPath));
+        var components = fullPath[current.Length..]
+            .Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var component in components) {
+            var candidate = Path.Combine(current, component);
+            if (File.Exists(candidate) || Directory.Exists(candidate)) {
+                FileSystemInfo info = Directory.Exists(candidate)
+                    ? new DirectoryInfo(candidate)
+                    : new FileInfo(candidate);
+                current = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? candidate;
+            } else {
+                current = candidate;
+            }
+        }
+        return current;
     }
 
     private string ResolveSafeDestination(string userPath) {
@@ -546,22 +563,7 @@ public class FileBrowserService {
         if (string.IsNullOrWhiteSpace(userPath))
             throw new ArgumentException("Empty destination", nameof(userPath));
         var full = Path.GetFullPath(userPath);
-        if (File.Exists(full) || Directory.Exists(full))
-            return ResolveSafe(full, mustExist: true);
-
-        var missing = new Stack<string>();
-        var existing = full;
-        while (!File.Exists(existing) && !Directory.Exists(existing)) {
-            var parent = Path.GetDirectoryName(existing);
-            if (string.IsNullOrEmpty(parent) || parent == existing) break;
-            missing.Push(Path.GetFileName(existing));
-            existing = parent;
-        }
-
-        var canonical = File.Exists(existing) || Directory.Exists(existing)
-            ? ResolveSafe(existing, mustExist: true)
-            : existing;
-        while (missing.Count > 0) canonical = Path.Combine(canonical, missing.Pop());
+        var canonical = ResolveExistingPath(full);
         if (IsBlocked(canonical))
             throw new UnauthorizedAccessException($"Destination is blocked: {canonical}");
         return canonical;

--- a/tests/NINA.Polaris.Test/FileBrowserServiceTests.cs
+++ b/tests/NINA.Polaris.Test/FileBrowserServiceTests.cs
@@ -152,6 +152,39 @@ public class FileBrowserServiceTests {
             Throws.TypeOf<FileNotFoundException>());
     }
 
+    [Test]
+    public void ResolveSafe_SymlinkToBlockedFile_Refused() {
+        if (!OperatingSystem.IsLinux()) return;
+
+        var link = Path.Combine(_tmp, "shadow-link");
+        File.CreateSymbolicLink(link, "/etc/shadow");
+
+        Assert.That(() => _svc.ResolveSafe(link, mustExist: true),
+            Throws.TypeOf<UnauthorizedAccessException>());
+    }
+
+    [Test]
+    public void WriteText_SymlinkedDestinationParentToBlockedDirectory_Refused() {
+        if (!OperatingSystem.IsLinux()) return;
+
+        var link = Path.Combine(_tmp, "etc-link");
+        Directory.CreateSymbolicLink(link, "/etc");
+
+        Assert.That(
+            async () => await _svc.WriteTextAsync(
+                Path.Combine(link, "polaris-test.txt"), "x", overwrite: false),
+            Throws.TypeOf<UnauthorizedAccessException>());
+    }
+
+    [Test]
+    public async Task WriteText_NormalTemporaryDestination_Works() {
+        var path = Path.Combine(_tmp, "output.txt");
+
+        await _svc.WriteTextAsync(path, "x", overwrite: false);
+
+        Assert.That(await File.ReadAllTextAsync(path), Is.EqualTo("x"));
+    }
+
     // --- Mutations ----------------------------------------------------
 
     [Test]

--- a/tests/NINA.Polaris.Test/FileBrowserServiceTests.cs
+++ b/tests/NINA.Polaris.Test/FileBrowserServiceTests.cs
@@ -154,10 +154,11 @@ public class FileBrowserServiceTests {
 
     [Test]
     public void ResolveSafe_SymlinkToBlockedFile_Refused() {
-        if (!OperatingSystem.IsLinux()) return;
+        if (!OperatingSystem.IsLinux())
+            Assert.Ignore("Symbolic-link test requires Linux");
 
         var link = Path.Combine(_tmp, "shadow-link");
-        File.CreateSymbolicLink(link, "/etc/shadow");
+        File.CreateSymbolicLink(link, "/proc/self/status");
 
         Assert.That(() => _svc.ResolveSafe(link, mustExist: true),
             Throws.TypeOf<UnauthorizedAccessException>());
@@ -165,7 +166,8 @@ public class FileBrowserServiceTests {
 
     [Test]
     public void WriteText_SymlinkedDestinationParentToBlockedDirectory_Refused() {
-        if (!OperatingSystem.IsLinux()) return;
+        if (!OperatingSystem.IsLinux())
+            Assert.Ignore("Symbolic-link test requires Linux");
 
         var link = Path.Combine(_tmp, "etc-link");
         Directory.CreateSymbolicLink(link, "/etc");
@@ -173,6 +175,32 @@ public class FileBrowserServiceTests {
         Assert.That(
             async () => await _svc.WriteTextAsync(
                 Path.Combine(link, "polaris-test.txt"), "x", overwrite: false),
+            Throws.TypeOf<UnauthorizedAccessException>());
+    }
+
+    [Test]
+    public void OpenRead_IntermediateSymlinkToBlockedDirectory_Refused() {
+        if (!OperatingSystem.IsLinux())
+            Assert.Ignore("Symbolic-link test requires Linux");
+
+        var link = Path.Combine(_tmp, "proc-link");
+        Directory.CreateSymbolicLink(link, "/proc");
+
+        Assert.That(
+            () => _svc.OpenRead(Path.Combine(link, "self", "status")),
+            Throws.TypeOf<UnauthorizedAccessException>());
+    }
+
+    [Test]
+    public void ResolveSafe_NonexistentPathThroughBlockedSymlink_Refused() {
+        if (!OperatingSystem.IsLinux())
+            Assert.Ignore("Symbolic-link test requires Linux");
+
+        var link = Path.Combine(_tmp, "proc-link");
+        Directory.CreateSymbolicLink(link, "/proc");
+
+        Assert.That(
+            () => _svc.ResolveSafe(Path.Combine(link, "not-created.txt"), mustExist: false),
             Throws.TypeOf<UnauthorizedAccessException>());
     }
 


### PR DESCRIPTION
I fixed the FILES path validator so existing `symlinks` are resolved before blocked-path checks, and non-existing destinations validate their nearest existing parent.

I added Linux regression coverage for `symlinked` reads and write destinations, plus a normal temporary write.